### PR TITLE
refactor: rename git_force_push_selected to git_force_push_chain

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,8 @@
       "Bash(/Users/youngchang/shell-scripts/git/git-tools.sh doctor)",
       "Bash(git add:*)",
       "Bash(gh pr close:*)",
-      "Bash(git stash:*)"
+      "Bash(git stash:*)",
+      "Bash(git checkout:*)"
     ],
     "deny": [],
     "ask": []

--- a/.gitconfig.tmpl
+++ b/.gitconfig.tmpl
@@ -97,8 +97,8 @@
 		git push origin $(git branch --show-current)"
 	psf = "!# custom - Push current branch to remote force.;\n\
 		git push origin $(git branch --show-current) --force-with-lease --no-verify"
-	pfs = "!# Push force selected - Force push selected branches;\n \
-		gt force-push-selected"
+	pfc = "!# Push force chain - Force push branch chain;\n \
+		gt force-push-chain"
 	pl = "!# custom - Pull current branch from remote.;\n\
 		git pull origin $(git branch --show-current)"
 	
@@ -266,7 +266,7 @@
 # Core shell-scripts commands:
 # git bb               # Interactive branch management
 # git c-s              # Interactive commit selection  
-# git pfs              # Force push selected branches
+# git pfc              # Force push branch chain
 # git alias-doctor     # Check dependencies
 #
 # Branch operations:
@@ -304,7 +304,7 @@
 # Method 2: Quick essential setup
 # git config --global alias.bb "!gt branch-tools"
 # git config --global alias.c-s "!gt commit-select"
-# git config --global alias.pfs "!gt force-push-selected"
+# git config --global alias.pfc "!gt force-push-chain"
 # git config --global alias.alias-doctor "!gt alias-doctor"
 
 # Method 3: Include this file (advanced users)
@@ -332,4 +332,4 @@
 # ✅ Copy-to-clipboard functionality for branches and commits
 # ✅ Enhanced logging with multiple format options
 # ✅ Comprehensive branch, commit, stash, and diff management
-# ✅ Advanced operations like replay-onto and force-push-selected
+# ✅ Advanced operations like replay-onto and force-push-chain

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Git aliases for seamless workflow integration:
 ```bash
 git bb            # Branch tools
 git c-s           # Commit select  
-git pfs           # Force push selected
+git pfc           # Force push chain
 ```
 
 ### 3. Direct Function Access (Advanced)

--- a/README.kr.md
+++ b/README.kr.md
@@ -45,7 +45,7 @@ source ~/.zshrc
 # 4. Git alias 설정 (.gitconfig.tmpl 참조)
 git config --global alias.bb "!gt branch-tools"
 git config --global alias.c-s "!gt commit-select"
-git config --global alias.pfs "!gt force-push-selected"
+git config --global alias.pfc "!gt force-push-chain"
 git config --global alias.al "!gt alias-select"
 
 # 5. 실행 권한 확인 (필요시)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ source ~/.zshrc
 # 4. Git alias setup (refer to .gitconfig.tmpl)
 git config --global alias.bb "!gt branch-tools"
 git config --global alias.c-s "!gt commit-select"
-git config --global alias.pfs "!gt force-push-selected"
+git config --global alias.pfc "!gt force-push-chain"
 git config --global alias.al "!gt alias-select"
 
 # 5. Ensure execution permissions (if needed)

--- a/git/CLAUDE.md
+++ b/git/CLAUDE.md
@@ -59,7 +59,7 @@ gt doctor         # dependency check
 # .gitconfig setup
 [alias]
     bb = "!gt branch-tools"
-    pfs = "!gt force-push-selected"
+    pfc = "!gt force-push-chain"
     c-s = "!gt commit-select"
     doctor = "!gt alias-doctor"
 ```
@@ -97,14 +97,14 @@ gt doctor    # Check all dependencies and git alias configuration
 ```bash
 gt branch-tools      # or gt bb
 gt commit-select     # or gt c-s
-gt force-push-selected  # or gt pfs
+gt force-push-chain     # or gt pfc
 gt help              # Show available commands
 ```
 
 ### Git Alias Usage
 ```bash
 git bb       # Branch tools
-git pfs      # Force push selected
+git pfc      # Force push chain
 git c-s      # Commit select
 git doctor   # Dependency check
 ```
@@ -210,7 +210,7 @@ gt doctor
 - `gt update`: Update with rebase
 
 ### Advanced Tools
-- `gt force-push-selected` (`gt pfs`): Multi-branch force push
+- `gt force-push-chain` (`gt pfc`): Multi-branch force push
 - `gt replay-onto`: Replay commits onto branch
 - `gt tag-refresh`: Interactive tag refresh
 
@@ -225,7 +225,7 @@ The tool integrates seamlessly with Git through aliases. Users typically add the
 ```ini
 [alias]
     bb = "!gt branch-tools"
-    pfs = "!gt force-push-selected"  
+    pfc = "!gt force-push-chain"  
     c-s = "!gt commit-select"
     doctor = "!gt alias-doctor"
 ```

--- a/git/README.kr.md
+++ b/git/README.kr.md
@@ -48,7 +48,7 @@
 - `gt update` - rebase로 업데이트
 
 #### 🚀 고급 도구
-- `gt force-push-selected` (또는 `gt pfs`) - 인터랙티브 다중 브랜치 force push
+- `gt force-push-chain` (또는 `gt pfc`) - 인터랙티브 다중 브랜치 force push
 - `gt replay-onto` - 브랜치로 커밋 replay
 - `gt replay-onto-main` - 메인으로 커밋 replay
 - `gt tag-refresh` - 인터랙티브 태그 갱신
@@ -114,7 +114,7 @@ gt doctor          # 의존성 체크
 # .gitconfig에 추가
 [alias]
     bb = "!gt branch-tools"
-    pfs = "!gt force-push-selected"
+    pfc = "!gt force-push-chain"
     c-s = "!gt commit-select"
     al = "!gt alias-select"
 ```
@@ -142,7 +142,7 @@ gt doctor          # 의존성 체크
 ```ini
 [alias]
     bb = "!gt branch-tools"
-    pfs = "!gt force-push-selected"
+    pfc = "!gt force-push-chain"
     c-s = "!gt commit-select"
     al = "!gt alias-select"
 ```

--- a/git/README.md
+++ b/git/README.md
@@ -54,7 +54,7 @@ Comprehensive Git workflow enhancement tools with interactive operations.
 
 #### 🚀 Advanced Tools
 
-- `gt force-push-selected` (or `gt pfs`) - Interactive multi-branch force push
+- `gt force-push-chain` (or `gt pfc`) - Interactive multi-branch force push
 - `gt replay-onto` - Replay commits onto branch
 - `gt replay-onto-main` - Replay commits onto main
 - `gt tag-refresh` - Interactive tag refresh
@@ -122,7 +122,7 @@ gt doctor          # Dependency check
 # Add to .gitconfig
 [alias]
     bb = "!gt branch-tools"
-    pfs = "!gt force-push-selected"
+    pfc = "!gt force-push-chain"
     c-s = "!gt commit-select"
     al = "!gt alias-select"
 ```
@@ -153,7 +153,7 @@ Aliases in `.gitconfig`:
 ```ini
 [alias]
     bb = "!gt branch-tools"
-    pfs = "!gt force-push-selected"
+    pfc = "!gt force-push-chain"
     c-s = "!gt commit-select"
     al = "!gt alias-select"
 ```


### PR DESCRIPTION
## Summary

**Problem/Purpose:**
The `git_force_push_selected` function name was unclear and didn't properly convey that it performs force push operations on a chain of connected branches. Additionally, the branch selection showed all branches instead of only child branches of the current branch.

**Solution/Method:**
- Renamed function from `git_force_push_selected` to `git_force_push_chain` for better clarity about force push context
- Updated command from `force-push-selected` to `force-push-chain` 
- Changed git alias from `pfs` to `pfc` (push force chain)
- Improved branch selection logic to only show child branches of current branch (branches that have current branch as ancestor)
- Updated all documentation, configuration templates, and help text across the codebase


<!-- ## Review Points (Optional) -->


## Test

Verified function is accessible and branch selection logic works correctly by testing:
- Function rename and command dispatching works
- New alias `pfc` and command `force-push-chain` are properly registered
- Branch selection now filters to show only child branches of current branch

<!-- ## Backlog (Optional) -->

<!-- ## LLM Context (Optional) -->
<!-- If this change involved LLM assistance, please describe what rules or prompts were used -->
<!-- 💡 Reference question: "What instructions or rules did you provide to the LLM for this work? Please share any prompts or guides you used." -->

## References

- Related Links: Refactoring to improve command naming clarity and branch selection behavior