### PR TITLE
config: add PR template files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,10 @@ __pycache__/
 # Local Claude settings (user-specific)
 .claude/settings.local.json
 
+# PR template temporary files
+pr_body.md
+pr_body_updated.md
+
 
 
 


### PR DESCRIPTION
## Summary

**Problem/Purpose:**
Temporary PR template files like `pr_body.md` and `pr_body_updated.md` are being created during PR generation workflows and need to be excluded from version control to keep the repository clean.

**Solution/Method:**
- Added `pr_body.md` and `pr_body_updated.md` to `.gitignore` under the existing "Claude Code Configuration" section
- These temporary files are generated during the automated PR creation process and should not be tracked in Git
- Prevents accidental commits of temporary files while keeping the PR generation workflow clean

## Test

Describe what testing was performed: 
- Verified that PR template files are properly ignored by Git
- Confirmed existing `.gitignore` patterns still work correctly  
- Tested that temporary files created during PR generation are excluded from `git status`

## References

- Related Links: N/A